### PR TITLE
Update POM with correct Java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,17 +56,9 @@
 	  <sonar.organization>spdx</sonar.organization>
 	  <sonar.projectKey>spdx-to-osv</sonar.projectKey>
 	  <dependency-check-maven.version>7.2.1</dependency-check-maven.version>
+	  <javadoc.opts>-Xdoclint:none</javadoc.opts>
     </properties>
 	<profiles>
-		<profile>
-			<id>doclint-java8-disable</id>
-			<activation>
-				<jdk>[1.8,11)</jdk>
-			</activation>
-			<properties>
-				<javadoc.opts>-Xdoclint:none</javadoc.opts>
-			</properties>
-		</profile>
 		<profile>
 			<id>gpg-signing</id>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,)</jdk>
+				<jdk>[1.8,11)</jdk>
 			</activation>
 			<properties>
 				<javadoc.opts>-Xdoclint:none</javadoc.opts>
@@ -163,8 +163,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>


### PR DESCRIPTION
The indirect dependency on Apache Jena requires Java 11

This commit updates the POM file to reflect the correct Java versions in the POM file.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>